### PR TITLE
Update cviebrock/eloquent-sluggable dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "cviebrock/eloquent-sluggable": "^4.6"
+        "cviebrock/eloquent-sluggable": "6.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I took a minute to upgrade the dependency. This should install the latest eloquent-sluggable that's compatible with Laravel 6.0.

I think this could be a breaking change, but i think it's a welcome one. The docs should be updated to reflect that too..

Also, this should probably fix #11 