### PR TITLE
Fix Create resource page not loading

### DIFF
--- a/src/PageResource.php
+++ b/src/PageResource.php
@@ -61,7 +61,7 @@ class PageResource extends Resource
                 ->onlyOnForms(),
 
             Text::make(__('Name'), 'name')
-                ->resolveUsing(function () {
+                ->displayUsing(function () {
                     return '<a target="_blank" href="'.route('page-manager', ['slug' => $this->slug]).'">'.$this->name.'</a>';
                 })
                 ->asHtml()


### PR DESCRIPTION
The Create resource page has a null slug and for some reason Nova is trying to run the `resolveUsing` method. This creates an issue where the `route` cannot be resolved.
`displayUsing` fixes this. 