### PR TITLE
fix: changing dependency to base nova resource

### DIFF
--- a/src/PageResource.php
+++ b/src/PageResource.php
@@ -2,13 +2,14 @@
 
 namespace Remipou\NovaPageManager;
 
-use Laravel\Nova\Resource;
+
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Image;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Trix;
+use Laravel\Nova\Resource;
 
 class PageResource extends Resource
 {

--- a/src/PageResource.php
+++ b/src/PageResource.php
@@ -2,7 +2,7 @@
 
 namespace Remipou\NovaPageManager;
 
-use App\Nova\Resource;
+use Laravel\Nova\Resource;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Image;

--- a/src/PageResource.php
+++ b/src/PageResource.php
@@ -2,7 +2,6 @@
 
 namespace Remipou\NovaPageManager;
 
-
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Image;


### PR DESCRIPTION
We should avoid forcing the user to keep own base Resource in `App\Nova\Dashboard` - previous approach, was forcing user to use that schema, or override totally resource comes from a package.