### PR TITLE
fix: using laravel controller instead app controller, which can not exists

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -2,7 +2,7 @@
 
 namespace Remipou\NovaPageManager;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 class PageController extends Controller
 {


### PR DESCRIPTION
Code in package, should not rely on any classes structure on user app side. Package will not work, when user not using `app/` dir, or has non-default namespace for it.